### PR TITLE
#8: ToString: Support custom output names via ToString.Include

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.bivektor.lombokt
-version=2.1.10-beta.1
+version=2.1.10-beta.2
 kotlinVersion=2.1.10
 deployerPluginVersion=0.16.0

--- a/lombokt-api/src/main/kotlin/lombokt/ToString.kt
+++ b/lombokt-api/src/main/kotlin/lombokt/ToString.kt
@@ -10,7 +10,7 @@ annotation class ToString(
 
   @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
   @Retention(AnnotationRetention.SOURCE)
-  annotation class Include()
+  annotation class Include(val name: String = "")
 
   @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
   @Retention(AnnotationRetention.SOURCE)

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
@@ -68,6 +68,26 @@ class ToStringTest {
     assertEquals("TestClass(name=John)", TestClass().toString())
   }
 
+  @Test
+  fun customIncludeName() {
+    @ToString
+    class IncludeNames(
+      @ToString.Include(name = "namex") var name: String = "John",
+      @ToString.Include(name="agex") private val age: Int = 10,
+    ) {
+      @ToString.Include(name="surnamex")
+      var surname: String? = "Doe"
+
+      @ToString.Include(name="emailx")
+      private val email: String? = null
+
+      @ToString.Include(name="computedx")
+      val computed: String get() = "computed"
+    }
+
+    assertEquals("IncludeNames(namex=John, agex=10, surnamex=Doe, emailx=null, computedx=computed)", IncludeNames().toString())
+  }
+
   @ToString
   private open class Person(
     open var name: String = "John",


### PR DESCRIPTION
* Add 'name' option to `ToString.Include` for overriding the field/property name in the output string
* Fix a bug regarding include check that was introduced in previous commit

Closes #8 