### PR TITLE
#10: Fix: [ToString] Computed getters must be explicitly included

### DIFF
--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
@@ -44,6 +44,7 @@ class ToStringTest {
       val name: String = "John"
         get() = field.uppercase()
 
+      @ToString.Include
       val age: Int get() = 10
     }
 
@@ -101,7 +102,10 @@ class ToStringTest {
     @ToString.Exclude
     private val address3: String = "excluded"
 
+    @ToString.Include
     val fullName: String get() = "$name $surname"
+
+    val computed: String get() = "computed"
   }
 
   @ToString(onlyExplicitlyIncluded = true)
@@ -116,5 +120,7 @@ class ToStringTest {
 
     @ToString.Include
     val fullName: String get() = "$name $surname"
+
+    val computed: String get() = "computed"
   }
 }


### PR DESCRIPTION
Require explicit include for computed getters (without backing fields)

Closes #10 