### PR TITLE
16: FIR declaration checkers and constraints for ToString and EqualsAndHashCode

### DIFF
--- a/lombokt-plugin/cli/src/main/kotlin/com/bivektor/lombokt/LomboktPlugin.kt
+++ b/lombokt-plugin/cli/src/main/kotlin/com/bivektor/lombokt/LomboktPlugin.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 class LomboktComponentRegistrar : CompilerPluginRegistrar() {
   override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
     IrGenerationExtension.registerExtension(LomboktIrGenerationExtension(configuration.messageCollector))
-    FirExtensionRegistrarAdapter.registerExtension(LomboktFirExtensionRegistrar(configuration.messageCollector))
+    FirExtensionRegistrarAdapter.registerExtension(LomboktFirExtensionRegistrar())
   }
 
   override val supportsK2: Boolean

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/LomboktFirExtensionRegistrar.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/LomboktFirExtensionRegistrar.kt
@@ -5,13 +5,12 @@ import com.bivektor.lombokt.fir.generators.EqualsAndHashcodeGenerator
 import com.bivektor.lombokt.fir.generators.ToStringGenerator
 import com.bivektor.lombokt.fir.services.EqualsAndHashCodeService
 import com.bivektor.lombokt.fir.services.ToStringService
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 
-class LomboktFirExtensionRegistrar(private val messageCollector: MessageCollector) : FirExtensionRegistrar() {
+class LomboktFirExtensionRegistrar : FirExtensionRegistrar() {
   override fun ExtensionRegistrarContext.configurePlugin() {
     +::ToStringGenerator
-    +EqualsAndHashcodeGenerator.factory(messageCollector)
+    +::EqualsAndHashcodeGenerator
     +::ToStringService
     +::EqualsAndHashCodeService
     +::LomboktCheckersComponent

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/LomboktFirExtensionRegistrar.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/LomboktFirExtensionRegistrar.kt
@@ -1,5 +1,6 @@
 package com.bivektor.lombokt.fir
 
+import com.bivektor.lombokt.fir.checkers.LomboktCheckersComponent
 import com.bivektor.lombokt.fir.generators.EqualsAndHashcodeGenerator
 import com.bivektor.lombokt.fir.generators.ToStringGenerator
 import com.bivektor.lombokt.fir.services.EqualsAndHashCodeService
@@ -9,9 +10,10 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 
 class LomboktFirExtensionRegistrar(private val messageCollector: MessageCollector) : FirExtensionRegistrar() {
   override fun ExtensionRegistrarContext.configurePlugin() {
-    +ToStringGenerator.factory(messageCollector)
+    +::ToStringGenerator
     +EqualsAndHashcodeGenerator.factory(messageCollector)
     +::ToStringService
     +::EqualsAndHashCodeService
+    +::LomboktCheckersComponent
   }
 }

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/LomboktFirUtils.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/LomboktFirUtils.kt
@@ -1,21 +1,58 @@
 package com.bivektor.lombokt.fir
 
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.hasModifier
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
+import org.jetbrains.kotlin.fir.declarations.utils.isFinal
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.isExtension
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 
-data class NamedFunctionDescriptor(val name: Name, val valueParameterTypes: List<ConeKotlinType>)
+data class NamedFunctionDescriptor(val name: Name, val valueParameterTypes: List<ConeKotlinType>) {
+  val predicate: (FirNamedFunctionSymbol) -> Boolean = {
+    !it.isExtension &&
+      it.name == name &&
+      it.valueParameterSymbols.map { it.resolvedReturnType } == valueParameterTypes
+  }
+}
 
-fun FirClassSymbol<*>.getDeclaredFunction(
-  descriptor: NamedFunctionDescriptor,
-): FirNamedFunctionSymbol? = declarationSymbols.filterIsInstance<FirNamedFunctionSymbol>().singleOrNull {
-  !it.isExtension &&
-    it.name == descriptor.name &&
-    it.valueParameterSymbols.map { it.resolvedReturnType } == descriptor.valueParameterTypes
+fun FirClassSymbol<*>.isFunctionDeclaredOrNotOverridable(
+  session: FirSession, predicate: (FirNamedFunctionSymbol) -> Boolean
+): Boolean = findNamedFunction(session, predicate, true)?.let { it.second || it.first.isFinal } == true
+
+private fun FirClassSymbol<*>.findNamedFunction(
+  session: FirSession,
+  predicate: (FirNamedFunctionSymbol) -> Boolean,
+  recurseSuperTypes: Boolean = false
+): Pair<FirNamedFunctionSymbol, Boolean>? {
+  val declared = getDeclaredFunction(predicate)
+  if (declared != null) return Pair(declared, true)
+  if (!recurseSuperTypes) return null
+  for (superType in resolvedSuperTypes) {
+    val superTypeSymbol = superType.toClassSymbol(session) ?: continue
+    if (superTypeSymbol.classKind != ClassKind.CLASS) continue
+    val found = superTypeSymbol.findNamedFunction(session, predicate, true)
+    if (found != null) return Pair(found.first, false)
+  }
+
+  return null
+}
+
+private fun FirClassSymbol<*>.getDeclaredFunction(predicate: (FirNamedFunctionSymbol) -> Boolean): FirNamedFunctionSymbol? =
+  declarationSymbols.filterIsInstance<FirNamedFunctionSymbol>().firstOrNull(predicate)
+
+fun FirClassSymbol<*>.findAnnotation(
+  session: FirSession, annotationClassId: ClassId, withArguments: Boolean = false
+): FirAnnotation? {
+  val annotations = if (withArguments) resolvedAnnotationsWithArguments else resolvedAnnotationsWithClassIds
+  return annotations.find { it.toAnnotationClassId(session) == annotationClassId }
 }
 
 val FirClassSymbol<*>.isValueClass get() = hasModifier(KtTokens.VALUE_KEYWORD)

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/EqualsAndHashCodeClassChecker.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/EqualsAndHashCodeClassChecker.kt
@@ -1,0 +1,19 @@
+package com.bivektor.lombokt.fir.checkers
+
+import com.bivektor.lombokt.fir.services.equalsAndHashCodeService
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.declarations.FirClass
+
+object EqualsAndHashCodeClassChecker : FirClassChecker(MppCheckerKind.Common) {
+  override fun check(
+    declaration: FirClass,
+    context: CheckerContext,
+    reporter: DiagnosticReporter
+  ) {
+    val equalsAndHashCodeService = context.session.equalsAndHashCodeService
+    equalsAndHashCodeService.checkClass(declaration, context, reporter)
+  }
+}

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktCheckersComponent.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktCheckersComponent.kt
@@ -9,6 +9,6 @@ class LomboktCheckersComponent(session: FirSession) : FirAdditionalCheckersExten
   override val declarationCheckers: DeclarationCheckers
     get() = object: DeclarationCheckers() {
       override val classCheckers: Set<FirClassChecker>
-        get() = setOf(ToStringClassChecker)
+        get() = setOf(ToStringClassChecker, EqualsAndHashCodeClassChecker)
     }
 }

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktCheckersComponent.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktCheckersComponent.kt
@@ -1,0 +1,14 @@
+package com.bivektor.lombokt.fir.checkers
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
+
+class LomboktCheckersComponent(session: FirSession) : FirAdditionalCheckersExtension(session) {
+  override val declarationCheckers: DeclarationCheckers
+    get() = object: DeclarationCheckers() {
+      override val classCheckers: Set<FirClassChecker>
+        get() = setOf(ToStringClassChecker)
+    }
+}

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktDiagnostics.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktDiagnostics.kt
@@ -1,0 +1,10 @@
+package com.bivektor.lombokt.fir.checkers
+
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.diagnostics.error1
+import org.jetbrains.kotlin.diagnostics.warning1
+
+object LomboktDiagnostics {
+  val UNSUPPORTED_CLASS_TYPE by error1<PsiElement, String>()
+  val FUNCTION_DECLARED_OR_NOT_OVERRIDABLE by warning1<PsiElement, String>()
+}

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/ToStringClassChecker.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/ToStringClassChecker.kt
@@ -1,0 +1,20 @@
+package com.bivektor.lombokt.fir.checkers
+
+import com.bivektor.lombokt.fir.services.toStringService
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.declarations.FirClass
+
+object ToStringClassChecker : FirClassChecker(MppCheckerKind.Common) {
+
+  override fun check(
+    declaration: FirClass,
+    context: CheckerContext,
+    reporter: DiagnosticReporter
+  ) {
+    val toStringService = context.session.toStringService
+    toStringService.checkClass(declaration, context, reporter)
+  }
+}

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/EqualsAndHashcodeGenerator.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/EqualsAndHashcodeGenerator.kt
@@ -1,16 +1,9 @@
 package com.bivektor.lombokt.fir.generators
 
-import com.bivektor.lombokt.LomboktNames.EQUALS_METHOD_NAME
-import com.bivektor.lombokt.LomboktNames.HASHCODE_METHOD_NAME
 import com.bivektor.lombokt.PluginKeys.EqualsHashCodeKey
 import com.bivektor.lombokt.fir.NamedFunctionDescriptor
-import com.bivektor.lombokt.fir.isFunctionDeclaredOrNotOverridable
-import com.bivektor.lombokt.fir.isValueClass
 import com.bivektor.lombokt.fir.services.EqualsAndHashCodeService
 import com.bivektor.lombokt.fir.services.equalsAndHashCodeService
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
@@ -23,48 +16,32 @@ import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.Name
 
 open class EqualsAndHashcodeGenerator(
-  session: FirSession,
-  private val messageCollector: MessageCollector
+  session: FirSession
 ) : FirDeclarationGenerationExtension(session) {
 
   private val equalsAndHashCodeService: EqualsAndHashCodeService by lazy { session.equalsAndHashCodeService }
 
-  private val equalsFunction: NamedFunctionDescriptor by lazy {
-    NamedFunctionDescriptor(EQUALS_METHOD_NAME, listOf(session.builtinTypes.nullableAnyType.coneType))
-  }
+  private val equalsFunction: NamedFunctionDescriptor get() = equalsAndHashCodeService.equalsFunction
 
-  private val hashCodeFunction = NamedFunctionDescriptor(HASHCODE_METHOD_NAME, emptyList())
+  private val hashCodeFunction: NamedFunctionDescriptor get() = equalsAndHashCodeService.hashCodeFunction
 
   override fun getCallableNamesForClass(classSymbol: FirClassSymbol<*>, context: MemberGenerationContext): Set<Name> {
     if (!isSuitableClass(classSymbol)) return emptySet()
+
+    // TODO - LOMBOKT-17 - We put this check here because we don't want to do it twice for each method. Is it ok?
+    if (equalsAndHashCodeService.isAnyFunctionDeclaredOrNotOverridable(classSymbol)) return emptySet()
+
     return setOf(equalsFunction.name, hashCodeFunction.name)
   }
 
-  private fun isSuitableClass(classSymbol: FirClassSymbol<*>): Boolean {
-    if (classSymbol.classKind != ClassKind.CLASS || classSymbol.isValueClass) return false
-    if (!equalsAndHashCodeService.isAnnotated(classSymbol)) return false
-    if (classSymbol.isFunctionDeclaredOrNotOverridable(
-        session,
-        equalsFunction
-      ) || classSymbol.isFunctionDeclaredOrNotOverridable(session, hashCodeFunction)
-    ) {
-      messageCollector.report(
-        CompilerMessageSeverity.LOGGING,
-        eitherFunctionAlreadyDeclaredMessage(classSymbol)
-      )
-      return false
-    }
-
-    return true
-  }
+  private fun isSuitableClass(classSymbol: FirClassSymbol<*>) =
+    equalsAndHashCodeService.isSuitableClassType(classSymbol) && equalsAndHashCodeService.isAnnotated(classSymbol)
 
   override fun generateFunctions(
     callableId: CallableId,
     context: MemberGenerationContext?
   ): List<FirNamedFunctionSymbol> {
     val classSymbol = context?.owner ?: return emptyList()
-
-
     val callableName = callableId.callableName
     return when (callableName) {
       equalsFunction.name -> listOf(generateEqualsMethod(classSymbol).symbol)
@@ -72,10 +49,6 @@ open class EqualsAndHashcodeGenerator(
       else -> error("Unexpected callable name: $callableName")
     }
   }
-
-  private fun eitherFunctionAlreadyDeclaredMessage(classSymbol: FirClassSymbol<*>) =
-    "Skipping '${equalsFunction.name}' and '${hashCodeFunction.name}' generation on '${classSymbol.classId}'. " +
-      "The class is annotated with '${equalsAndHashCodeService.annotationName}' but it already declares one of these methods or those methods are final in a super class"
 
   private fun generateEqualsMethod(
     classSymbol: FirClassSymbol<*>
@@ -101,10 +74,4 @@ open class EqualsAndHashcodeGenerator(
   ) {
     modality = Modality.OPEN
   }
-
-  companion object {
-    internal fun factory(messageCollector: MessageCollector): Factory =
-      Factory { session -> EqualsAndHashcodeGenerator(session, messageCollector) }
-  }
-
 }

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/ToStringGenerator.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/ToStringGenerator.kt
@@ -1,15 +1,8 @@
 package com.bivektor.lombokt.fir.generators
 
-import com.bivektor.lombokt.LomboktNames.TO_STRING_METHOD_NAME
 import com.bivektor.lombokt.PluginKeys
-import com.bivektor.lombokt.fir.NamedFunctionDescriptor
-import com.bivektor.lombokt.fir.getDeclaredFunction
-import com.bivektor.lombokt.fir.isValueClass
 import com.bivektor.lombokt.fir.services.ToStringService
 import com.bivektor.lombokt.fir.services.toStringService
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.LOGGING
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
@@ -21,45 +14,32 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.Name
 
-private val toStringFunction = NamedFunctionDescriptor(TO_STRING_METHOD_NAME, emptyList())
 
 open class ToStringGenerator(
-  session: FirSession,
-  private val messageCollector: MessageCollector
+  session: FirSession
 ) : FirDeclarationGenerationExtension(session) {
 
   private val toStringService: ToStringService by lazy {
     session.toStringService
   }
 
-  private val methodName = toStringFunction.name
+  private val functionName: Name get() = toStringService.toStringFunction.name
 
   override fun getCallableNamesForClass(classSymbol: FirClassSymbol<*>, context: MemberGenerationContext): Set<Name> {
-    if (isSuitableClass(classSymbol)) return setOf(methodName)
+    if (isSuitableClass(classSymbol)) return setOf(functionName)
     return emptySet()
   }
 
   private fun isSuitableClass(classSymbol: FirClassSymbol<*>): Boolean {
-    if (!(classSymbol.classKind == ClassKind.CLASS || classSymbol.classKind == ClassKind.OBJECT)) return false
-    if (classSymbol.isValueClass) return false
-    return toStringService.isAnnotated(classSymbol)
+    return toStringService.isSuitableClassType(classSymbol) && toStringService.isAnnotated(classSymbol)
   }
 
   override fun generateFunctions(
     callableId: CallableId,
     context: MemberGenerationContext?
   ): List<FirNamedFunctionSymbol> {
-    val callableName = callableId.callableName
-    require(callableName == methodName) { "Unexpected callable name: $callableName" }
     val classSymbol = context?.owner ?: return emptyList()
-    if (classSymbol.getDeclaredFunction(toStringFunction) != null) {
-      messageCollector.report(
-        LOGGING,
-        "Skipping '$methodName' generation on '${classSymbol.classId}'. The class is annotated with '${toStringService.annotationName}' but it already declares a method with the same name"
-      )
-      return emptyList()
-    }
-
+    if (toStringService.isFunctionDeclaredOrNotOverridable(classSymbol)) return emptyList()
     return listOf(generateToStringMethod(classSymbol).symbol)
   }
 
@@ -68,15 +48,9 @@ open class ToStringGenerator(
   ): FirSimpleFunction = createMemberFunction(
     classSymbol,
     PluginKeys.ToStringKey,
-    methodName,
+    functionName,
     session.builtinTypes.stringType.coneType,
   ) {
     modality = Modality.OPEN
   }
-
-  internal companion object {
-    internal fun factory(messageCollector: MessageCollector): Factory =
-      Factory { session -> ToStringGenerator(session, messageCollector) }
-  }
-
 }

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/EqualsAndHashCodeService.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/EqualsAndHashCodeService.kt
@@ -1,8 +1,86 @@
 package com.bivektor.lombokt.fir.services
 
-import com.bivektor.lombokt.LomboktNames.EQUALS_HASHCODE_ANNOTATION_NAME as ANNOTATION_NAME
+import com.bivektor.lombokt.LomboktNames.EQUALS_METHOD_NAME
+import com.bivektor.lombokt.LomboktNames.HASHCODE_METHOD_NAME
+import com.bivektor.lombokt.fir.NamedFunctionDescriptor
+import com.bivektor.lombokt.fir.checkers.LomboktDiagnostics
+import com.bivektor.lombokt.fir.checkers.LomboktDiagnostics.UNSUPPORTED_CLASS_TYPE
+import com.bivektor.lombokt.fir.findAnnotation
+import com.bivektor.lombokt.fir.isFunctionDeclaredOrNotOverridable
+import com.bivektor.lombokt.fir.isValueClass
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.utils.isInline
+import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.name.ClassId
+import com.bivektor.lombokt.LomboktNames.EQUALS_HASHCODE_ANNOTATION_NAME as ANNOTATION_NAME
 
-class EqualsAndHashCodeService(session: FirSession) : AnnotatedClassMatchingService(session, ANNOTATION_NAME)
+private val annotationClassId = ClassId.topLevel(ANNOTATION_NAME)
+
+private val annotationSimpleName = ANNOTATION_NAME.shortName()
+
+class EqualsAndHashCodeService(session: FirSession) : AnnotatedClassMatchingService(session, ANNOTATION_NAME) {
+
+  val equalsFunction: NamedFunctionDescriptor by lazy {
+    NamedFunctionDescriptor(EQUALS_METHOD_NAME, listOf(session.builtinTypes.nullableAnyType.coneType))
+  }
+
+  val hashCodeFunction = HASHCODE_FUNCTION_DESCRIPTOR
+
+  private val anyFunctionPredicate: (FirNamedFunctionSymbol) -> Boolean = {
+    equalsFunction.predicate(it) || hashCodeFunction.predicate(it)
+  }
+
+  fun checkClass(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
+    val classSymbol = declaration.symbol
+    val annotation = classSymbol.findAnnotation(session, annotationClassId) ?: return
+    if (!isSuitableClassType(classSymbol)) {
+      reporter.reportOn(
+        annotation.source,
+        UNSUPPORTED_CLASS_TYPE,
+        "@${annotationSimpleName} is only supported on regular classes and objects, not on anonymous objects, interfaces, inline, value and enum classes.",
+        context
+      )
+
+      return
+    }
+
+    if (isAnyFunctionDeclaredOrNotOverridable(classSymbol)) {
+      reporter.reportOn(
+        annotation.source,
+        LomboktDiagnostics.FUNCTION_DECLARED_OR_NOT_OVERRIDABLE,
+        "@${annotationSimpleName} is useless on this class, because '$EQUALS_METHOD_NAME' or '$HASHCODE_METHOD_NAME' method is already declared or final in a super class.",
+        context
+      )
+    }
+  }
+
+  fun isAnyFunctionDeclaredOrNotOverridable(classSymbol: FirClassSymbol<*>): Boolean {
+    return classSymbol.isFunctionDeclaredOrNotOverridable(session, anyFunctionPredicate)
+  }
+
+  fun isSuitableClassType(symbol: FirClassSymbol<*>): Boolean {
+    return when {
+      // Allow only regular classes not objects, enum classes & entries, interfaces, annotation classes
+      symbol.classKind != ClassKind.CLASS -> false
+
+      // Disallow anonymous objects
+      symbol is FirAnonymousObjectSymbol -> false
+
+      // Disallow special types
+      symbol.isInline || symbol.isValueClass -> false
+
+      else -> true
+    }
+  }
+}
+
+private val HASHCODE_FUNCTION_DESCRIPTOR = NamedFunctionDescriptor(HASHCODE_METHOD_NAME, emptyList())
 
 val FirSession.equalsAndHashCodeService: EqualsAndHashCodeService by FirSession.sessionComponentAccessor()

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/ToStringService.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/ToStringService.kt
@@ -1,8 +1,76 @@
 package com.bivektor.lombokt.fir.services
 
 import com.bivektor.lombokt.LomboktNames.TO_STRING_ANNOTATION_NAME
+import com.bivektor.lombokt.LomboktNames.TO_STRING_METHOD_NAME
+import com.bivektor.lombokt.fir.NamedFunctionDescriptor
+import com.bivektor.lombokt.fir.checkers.LomboktDiagnostics
+import com.bivektor.lombokt.fir.checkers.LomboktDiagnostics.UNSUPPORTED_CLASS_TYPE
+import com.bivektor.lombokt.fir.findAnnotation
+import com.bivektor.lombokt.fir.isFunctionDeclaredOrNotOverridable
+import com.bivektor.lombokt.fir.isValueClass
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.utils.isInline
+import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.name.ClassId
 
-class ToStringService(session: FirSession) : AnnotatedClassMatchingService(session, TO_STRING_ANNOTATION_NAME)
+private val toStringAnnotationClassId = ClassId.topLevel(TO_STRING_ANNOTATION_NAME)
+
+private val annotationSimpleName = TO_STRING_ANNOTATION_NAME.shortName()
+
+class ToStringService(session: FirSession) : AnnotatedClassMatchingService(session, TO_STRING_ANNOTATION_NAME) {
+
+  val toStringFunction = TO_STRING_FUNCTION_DESCRIPTOR
+
+  fun checkClass(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
+    val classSymbol = declaration.symbol
+    val annotation = classSymbol.findAnnotation(session, toStringAnnotationClassId) ?: return
+    if (!isSuitableClassType(classSymbol)) {
+      reporter.reportOn(
+        annotation.source,
+        UNSUPPORTED_CLASS_TYPE,
+        "@${annotationSimpleName} is only supported on regular classes and objects, not on anonymous objects, interfaces, inline, value and enum classes.",
+        context
+      )
+
+      return
+    }
+
+    if (isFunctionDeclaredOrNotOverridable(classSymbol)) {
+      reporter.reportOn(
+        annotation.source,
+        LomboktDiagnostics.FUNCTION_DECLARED_OR_NOT_OVERRIDABLE,
+        "@${annotationSimpleName} is useless on this class, because the method is already declared or final in a super class.",
+        context
+      )
+    }
+  }
+
+  fun isSuitableClassType(symbol: FirClassSymbol<*>): Boolean {
+    return when {
+      // Allow only regular classes and objects, not enum classes & entries, interfaces, annotation classes
+      symbol.classKind != ClassKind.CLASS && symbol.classKind != ClassKind.OBJECT -> false
+
+      // Disallow anonymous objects
+      symbol is FirAnonymousObjectSymbol -> false
+
+      // Disallow special types
+      symbol.isInline || symbol.isValueClass -> false
+
+      else -> true
+    }
+  }
+
+  fun isFunctionDeclaredOrNotOverridable(classSymbol: FirClassSymbol<*>): Boolean {
+    return classSymbol.isFunctionDeclaredOrNotOverridable(session, toStringFunction.predicate)
+  }
+}
+
+private val TO_STRING_FUNCTION_DESCRIPTOR = NamedFunctionDescriptor(TO_STRING_METHOD_NAME, emptyList())
 
 val FirSession.toStringService: ToStringService by FirSession.sessionComponentAccessor()

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Nested
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 @Suppress("unused")
 class EqualsAndHashcodeTest {
@@ -459,9 +459,6 @@ class EqualsAndHashcodeTest {
     }
   }
 
-  @EqualsAndHashCode
-  interface PersonDao
-
   @Nested
   inner class DataClassTests {
 
@@ -538,16 +535,23 @@ class EqualsAndHashcodeTest {
       }
     }
 
-    assertEquals(Person("Jane"), Person("John"))
+    assertTrue { (Person("John").equals(Person("John"))) }
     assertEquals(99, Person("Jane").hashCode())
   }
 
   @Test
-  fun objectsNotSupported() {
-    assertFalse { TestObject.javaClass.declaredMethods.any { it.name == "equals" } }
-    assertFalse { TestObject.javaClass.declaredMethods.any { it.name == "hashCode" } }
+  fun `should skip if super method is final`() {
+    @EqualsAndHashCode
+    open class PersonFinal(val name: String)
+
+    @EqualsAndHashCode
+    class PersonFinalChild(name: String, val id: String) : PersonFinal(name)
+
+    val p1 = PersonFinalChild("a", "1")
+    val p2 = PersonFinalChild("a", "1")
+    assertEquals(p1, p2)
+    assertEquals(p1.hashCode(), p2.hashCode())
   }
 
-  @EqualsAndHashCode
-  object TestObject
+
 }

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
@@ -130,6 +130,20 @@ class ToStringTest {
     assertEquals("declared", TestObjectWithDeclaredMethod.toString())
   }
 
+  @Test
+  fun shouldSkipWhenSuperMethodFinal() {
+    open class ToStringFinal {
+      final override fun toString(): String {
+        return "fromSuper"
+      }
+    }
+
+    @ToString
+    open class Subject(val extra: String = "extra") : ToStringFinal()
+
+    assertEquals("fromSuper", Subject().toString())
+  }
+
   @ToString
   open class Person(
     open var name: String = "John",
@@ -187,5 +201,4 @@ class ToStringTest {
       return "declared"
     }
   }
-
 }


### PR DESCRIPTION
Closes #16 

- Enhanced `ToStringService` and `EqualsAndHashCodeService` to handle declaration checks 
- Simplified generators to use service methods for common tasks
- Removed MessageCollector dependencies from FIR generators because declaration checkers handle that work. We can add them again if we want to have some debug level logging
