### PR TITLE
#24: [EqualsAndHashCode]: Only use properties from the primary constructor for data classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,23 +78,36 @@ data class Order(
   @EqualsAndHashCode.Exclude
   val createdBy: String
 ) {
-  // This is also included and its getter is used by default
-  var code: String? = null
-    get() = field?.uppercase()
+  // This is not included because properties declared in class body are not supported for data classes
+  var code: String = "some"
 }
 
-@EqualsAndHashCode(doNotUseGetters=true)
-data class Order(
+@EqualsAndHashCode
+class Order(
   val orderId: String,
   val items: List<Item>,
 
   @EqualsAndHashCode.Exclude
   val createdBy: String
 ) {
-  // Field is used instead of getter. Compared to example above, equals is not affected but hashcode is
-  val code: String? = null
-    get() = field?.uppercase()
+  // This property is automatically included because this is not a data class. Its getter is used by default.
+  var code: String = "some"
+    get() = field.uppercase()
 }
+
+@EqualsAndHashCode(doNotUseGetters=true)
+class Order(
+  val orderId: String,
+  val items: List<Item>,
+
+  @EqualsAndHashCode.Exclude
+  val createdBy: String
+) {
+  // Direct field access. Getter is not used
+  var code: String = "some"
+    get() = field.uppercase()
+}
+
 
 @EqualsAndHashCode(onlyExplicitlyIncluded=true)
 class Order(

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktDiagnostics.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktDiagnostics.kt
@@ -7,4 +7,5 @@ import org.jetbrains.kotlin.diagnostics.warning1
 object LomboktDiagnostics {
   val UNSUPPORTED_CLASS_TYPE by error1<PsiElement, String>()
   val FUNCTION_DECLARED_OR_NOT_OVERRIDABLE by warning1<PsiElement, String>()
+  val ANNOTATED_DATA_CLASS_BODY_PROPERTY by error1<PsiElement, String>()
 }

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
@@ -175,9 +175,13 @@ class EqualsAndHashcodeTest {
   }
 
   @EqualsAndHashCode
-  private data class DataClass(val name: String, @EqualsAndHashCode.Exclude val age: Int) {
-    var extra: Int = 1
-      get() = field + 10
+  private data class DataClass(val name: String, @EqualsAndHashCode.Exclude var age: Int) {
+    var excludedByDefault: Int = 1
+  }
+
+  @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+  private data class DataClassExplicit(@EqualsAndHashCode.Include val name: String, var age: Int) {
+    var excludedByDefault: Int = 1
   }
 
   @Test
@@ -185,13 +189,21 @@ class EqualsAndHashcodeTest {
     val v1 = DataClass("a", 1)
     val v2 = DataClass("a", 2)
     val v3 = DataClass("b", 1)
-    val v4 = DataClass("a", 1).apply { extra = 11 }
+    val v4 = DataClass("a", 1).apply { excludedByDefault = 10 }
+
+    val explicit1 = DataClassExplicit("a", 1)
+    val explicit2 = DataClassExplicit("a", 2)
+    val explicit3 = DataClassExplicit("b", 1)
 
     assertEquals(v1, v2)
     assertEquals(v1.hashCode(), v2.hashCode())
     assertNotEquals(v1, v3)
-    assertNotEquals(v1, v4)
-    assertEquals(v4.hashCode(), calculateHashCode("a", 21))
+    assertEquals(v1, v4)
+    assertEquals(v1.hashCode(), v4.hashCode())
+    assertEquals(explicit1, explicit2)
+    assertEquals(explicit1.hashCode(), explicit2.hashCode())
+    assertNotEquals(explicit1, explicit3)
+    assertNotEquals(explicit1.hashCode(), explicit3.hashCode())
   }
 }
 


### PR DESCRIPTION
Properties declared in data class bodies are now excluded from equality and this is not optional.  Annotating such a property with `@EqualsAndHashCode.Include` causes a compilation error