### PR TITLE
[LOMBOKT-17]: Compiler performance improvements

### DIFF
--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlockBody
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
@@ -20,24 +19,12 @@ import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.name.Name
 
-class ToStringIrVisitor(
+class ToStringIrBodyGenerator(
   private val pluginContext: IrPluginContext,
   private val messageCollector: MessageCollector
-) : IrVisitorVoid() {
-
-  override fun visitElement(element: IrElement) {
-    when (element) {
-      is IrDeclaration,
-      is IrFile,
-      is IrModuleFragment -> element.acceptChildrenVoid(this)
-    }
-  }
-
-  override fun visitSimpleFunction(declaration: IrSimpleFunction) {
-    if (!declaration.isGeneratedByPluginKey(PluginKeys.ToStringKey)) {
-      return super.visitSimpleFunction(declaration)
-    }
-
+) {
+  fun processSimpleFunction(declaration: IrSimpleFunction) {
+    if (!declaration.isGeneratedByPluginKey(PluginKeys.ToStringKey)) return
     val classDeclaration = declaration.parent
     require(classDeclaration is IrClass) { "Function ${declaration.name} is not a member of a class" }
     val annotation = getAnnotationAttributes(classDeclaration)


### PR DESCRIPTION
* Combined `EqualsAndHashCode` and `ToString` IR visitors into a single visitor removing the need for multiple traversals of the tree. Note that old visitor classes are renamed in order to better convey their usage.
* Shared configuration of 'equals' and 'hashcode' IR body generation logic (e.g. annotation attributes and list of properties to be used) is now cached per single class visit in order to prevent redundant computation of the same data