### PR TITLE
[LOMBOKT-31]: EqualsAndHashCode - Exclude lateinits by default

### DIFF
--- a/lombokt-api/src/main/kotlin/lombokt/EqualsAndHashCode.kt
+++ b/lombokt-api/src/main/kotlin/lombokt/EqualsAndHashCode.kt
@@ -5,7 +5,8 @@ package lombokt
 annotation class EqualsAndHashCode(
   val onlyExplicitlyIncluded: Boolean = false,
   val callSuper: Boolean = false,
-  val doNotUseGetters: Boolean = false
+  val doNotUseGetters: Boolean = false,
+  val includeLateInits: Boolean = false
 ) {
 
   @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)

--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/LomboktIrGenerationExtension.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/LomboktIrGenerationExtension.kt
@@ -21,7 +21,7 @@ class LomboktIrGenerationExtension(private val messageCollector: MessageCollecto
 
   private class LomboktIrTransformer(
     private val pluginContext: IrPluginContext,
-    messageCollector: MessageCollector
+    private val messageCollector: MessageCollector
   ) : IrVisitorVoid() {
 
     private val toStringGenerator = ToStringIrBodyGenerator(pluginContext, messageCollector)
@@ -36,7 +36,7 @@ class LomboktIrGenerationExtension(private val messageCollector: MessageCollecto
 
     override fun visitClass(declaration: IrClass) {
       super.visitClass(declaration)
-      EqualsAndHashCodeIrBodyGenerator(declaration, pluginContext).processClass()
+      EqualsAndHashCodeIrBodyGenerator(declaration, pluginContext, messageCollector).processClass()
     }
 
     override fun visitSimpleFunction(declaration: IrSimpleFunction) {

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
@@ -205,6 +205,27 @@ class EqualsAndHashcodeTest {
     assertNotEquals(explicit1, explicit3)
     assertNotEquals(explicit1.hashCode(), explicit3.hashCode())
   }
+
+  @EqualsAndHashCode(includeLateInits = true)
+  private class LateInitsGlobalInclude {
+    lateinit var name: String
+  }
+
+  @EqualsAndHashCode
+  private class LateInitsExplicitIncludeOnProp {
+    @EqualsAndHashCode.Include lateinit var name: String
+  }
+
+  @Test
+  fun testLateInits() {
+    val a = LateInitsGlobalInclude().apply { name = "a" }
+    val b = LateInitsGlobalInclude().apply { name = "a" }
+    val c = LateInitsGlobalInclude().apply { name = "b" }
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+    assertNotEquals(a, c)
+    assertNotEquals(a.hashCode(), c.hashCode())
+  }
 }
 
 private fun calculateHashCode(vararg values: Any?): Int {


### PR DESCRIPTION
`lateinit` properties are now excluded by default from equality comparisons unless explicitly included. A new `includeLateInits` option on the `@EqualsAndHashCode` annotation allows including all `lateinit` properties 

Closes #31 