### PR TITLE
[LOMBOKT-34] EqualsAndHashCode - Fix the bug that causes unexpected compilation errors for lateinit properties

### DIFF
--- a/lombokt-api/src/main/kotlin/lombokt/EqualsAndHashCode.kt
+++ b/lombokt-api/src/main/kotlin/lombokt/EqualsAndHashCode.kt
@@ -3,9 +3,25 @@ package lombokt
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 annotation class EqualsAndHashCode(
+  /**
+   * When set to `true` only properties explicitly included are used. Note that for lateinit properties, if [includeLateInits]
+   * is also `true`, they are treated as if they are explicitly included.
+   * For other properties, including the ones in the primary constructor, [Include] annotation is required.
+   * Defaults to `false`
+   */
   val onlyExplicitlyIncluded: Boolean = false,
   val callSuper: Boolean = false,
   val doNotUseGetters: Boolean = false,
+
+  /**
+   * Whether to include lateinit properties. Defaults to `false`.
+   * When set to `true`, all lateinit properties are treated as if they are explicitly included.
+   *
+   * Note that lateinit properties are problematic for equality because equals and hashcode methods are expected to not
+   * throw exceptions but uninitialized lateinit properties throw runtime exceptions. That's why, if a lateinit property
+   * is not explicitly included either via this option or through [Include] annotation, compilation fails with an exception
+   * @see [onlyExplicitlyIncluded]
+   */
   val includeLateInits: Boolean = false
 ) {
 

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashCodeLateInitTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashCodeLateInitTest.kt
@@ -1,7 +1,6 @@
 package com.bivektor.lombokt
 
 import lombokt.EqualsAndHashCode
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashCodeLateInitTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashCodeLateInitTest.kt
@@ -1,0 +1,115 @@
+package com.bivektor.lombokt
+
+import lombokt.EqualsAndHashCode
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class EqualsAndHashCodeLateInitTest {
+  @EqualsAndHashCode(includeLateInits = true)
+  private class LateInitsGlobalInclude {
+    lateinit var included: String
+
+    @EqualsAndHashCode.Exclude
+    lateinit var excluded: String
+
+    override fun toString(): String {
+      return "$included/$excluded"
+    }
+  }
+
+  @Test
+  fun testLateInitsGlobalInclude() {
+    val a = LateInitsGlobalInclude().apply {
+      included = "a"
+      excluded = "b"
+    }
+
+    val b = LateInitsGlobalInclude().apply {
+      included = "a"
+      excluded = "c"
+    }
+
+    val c = LateInitsGlobalInclude().apply {
+      included = "b"
+      excluded = "b"
+    }
+
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+    assertNotEquals(a, c)
+    assertNotEquals(a.hashCode(), c.hashCode())
+  }
+
+  @EqualsAndHashCode
+  private class LateInitsExplicitIncludeOnProp {
+    @EqualsAndHashCode.Include
+    lateinit var included: String
+
+    @EqualsAndHashCode.Exclude
+    lateinit var excluded: String
+
+    override fun toString(): String {
+      return "$included/$excluded"
+    }
+  }
+
+  @Test
+  fun testLateInitsExplicitIncludeOnProp() {
+    val a = LateInitsExplicitIncludeOnProp().apply {
+      included = "a"
+      excluded = "b"
+    }
+
+    val b = LateInitsExplicitIncludeOnProp().apply {
+      included = "a"
+      excluded = "c"
+    }
+
+    val c = LateInitsExplicitIncludeOnProp().apply {
+      included = "b"
+      excluded = "b"
+    }
+
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+    assertNotEquals(a, c)
+    assertNotEquals(a.hashCode(), c.hashCode())
+  }
+
+  @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+  private class LateInitsExcludedByDefault {
+
+    @EqualsAndHashCode.Include
+    lateinit var included: String
+    lateinit var excluded: String
+
+    override fun toString(): String {
+      return "$included/$excluded"
+    }
+  }
+
+  @Test
+  fun testLateInitsExcludedByDefault() {
+    val a = LateInitsExcludedByDefault().apply {
+      included = "a"
+      excluded = "b"
+    }
+
+    val b = LateInitsExcludedByDefault().apply {
+      included = "a"
+      excluded = "c"
+    }
+
+    val c = LateInitsExcludedByDefault().apply {
+      included = "b"
+      excluded = "b"
+    }
+
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+    assertNotEquals(a, c)
+    assertNotEquals(a.hashCode(), c.hashCode())
+  }
+}

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
@@ -1,7 +1,6 @@
 package com.bivektor.lombokt
 
 import lombokt.EqualsAndHashCode
-import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/EqualsAndHashcodeTest.kt
@@ -1,6 +1,7 @@
 package com.bivektor.lombokt
 
 import lombokt.EqualsAndHashCode
+import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -204,27 +205,6 @@ class EqualsAndHashcodeTest {
     assertEquals(explicit1.hashCode(), explicit2.hashCode())
     assertNotEquals(explicit1, explicit3)
     assertNotEquals(explicit1.hashCode(), explicit3.hashCode())
-  }
-
-  @EqualsAndHashCode(includeLateInits = true)
-  private class LateInitsGlobalInclude {
-    lateinit var name: String
-  }
-
-  @EqualsAndHashCode
-  private class LateInitsExplicitIncludeOnProp {
-    @EqualsAndHashCode.Include lateinit var name: String
-  }
-
-  @Test
-  fun testLateInits() {
-    val a = LateInitsGlobalInclude().apply { name = "a" }
-    val b = LateInitsGlobalInclude().apply { name = "a" }
-    val c = LateInitsGlobalInclude().apply { name = "b" }
-    assertEquals(a, b)
-    assertEquals(a.hashCode(), b.hashCode())
-    assertNotEquals(a, c)
-    assertNotEquals(a.hashCode(), c.hashCode())
   }
 }
 


### PR DESCRIPTION
Closes #34 

* Entirely refactored property inclusion logic in the IR generator
* Added another check that, if a property is not eligible for inclusion but it is explicitly included, we throw a compilation error
* Moved lateinit properties test code into its own test class and covered different scenarios