### PR TITLE
LOMBOKT-33: ToString - Treat unitialized lateinit properties as NULL

### DIFF
--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/AbstractClassFunctionBlockBodyBuilder.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/AbstractClassFunctionBlockBodyBuilder.kt
@@ -24,6 +24,18 @@ abstract class AbstractClassFunctionBlockBodyBuilder(
     )
   }
 
+  protected fun irGetThisLateInitProperty(property: IrProperty, nullExpression: IrExpression): IrExpression {
+    // This is what ::isInitialized actually outputs in JVM. Instead of resolving and calling that extension function, we just mimic it
+    with(property) {
+      return irIfNull(
+        backingField!!.type,
+        irGetThisField(backingField!!),
+        nullExpression,
+        irGetThisProperty(this)
+      )
+    }
+  }
+
   protected fun irGetThisProperty(property: IrProperty) = with(property) {
     irCall(getter!!).apply {
       dispatchReceiver = irThis()

--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/AbstractClassFunctionBlockBodyBuilder.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/AbstractClassFunctionBlockBodyBuilder.kt
@@ -24,17 +24,6 @@ abstract class AbstractClassFunctionBlockBodyBuilder(
     )
   }
 
-  protected fun irGetThisLateInitProperty(property: IrProperty, nullExpression: IrExpression): IrExpression {
-    with(property) {
-      return irIfNull(
-        backingField!!.type,
-        irGetThisField(backingField!!),
-        nullExpression,
-        irGetThisProperty(this)
-      )
-    }
-  }
-
   protected fun irGetThisProperty(property: IrProperty) = with(property) {
     irCall(getter!!).apply {
       dispatchReceiver = irThis()

--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/AbstractClassFunctionBlockBodyBuilder.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/AbstractClassFunctionBlockBodyBuilder.kt
@@ -1,0 +1,45 @@
+package com.bivektor.lombokt.ir
+
+import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.IrField
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
+
+abstract class AbstractClassFunctionBlockBodyBuilder(
+  private val irFunction: IrFunction,
+  context: IrGeneratorContext,
+  scope: Scope,
+  startOffset: Int,
+  endOffset: Int
+) : IrBlockBodyBuilder(context, scope, startOffset, endOffset) {
+
+  protected fun irThis(): IrExpression {
+    val irDispatchReceiverParameter = irFunction.dispatchReceiverParameter!!
+    return IrGetValueImpl(
+      startOffset, endOffset,
+      irDispatchReceiverParameter.type,
+      irDispatchReceiverParameter.symbol
+    )
+  }
+
+  protected fun irGetThisLateInitProperty(property: IrProperty, nullExpression: IrExpression): IrExpression {
+    with(property) {
+      return irIfNull(
+        backingField!!.type,
+        irGetThisField(backingField!!),
+        nullExpression,
+        irGetThisProperty(this)
+      )
+    }
+  }
+
+  protected fun irGetThisProperty(property: IrProperty) = with(property) {
+    irCall(getter!!).apply {
+      dispatchReceiver = irThis()
+    }
+  }
+
+  protected fun irGetThisField(field: IrField) = irGetField(irThis(), field)
+}

--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
@@ -5,19 +5,19 @@ import com.bivektor.lombokt.PluginKeys
 import com.bivektor.lombokt.isGeneratedByPluginKey
 import getConstValueByName
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.backend.common.lower.irBlockBody
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.name.Name
+
+private const val UNINITIALIZED = "<uninitialized>"
 
 class ToStringIrBodyGenerator(
   private val pluginContext: IrPluginContext,
@@ -28,97 +28,92 @@ class ToStringIrBodyGenerator(
     val classDeclaration = declaration.parent
     require(classDeclaration is IrClass) { "Function ${declaration.name} is not a member of a class" }
     val annotation = getAnnotationAttributes(classDeclaration)
-    declaration.body = generateMethodBody(declaration, annotation)
+    declaration.body = ToStringFunctionBodyBuilder(declaration, annotation).let { builder ->
+      builder.blockBody {
+        builder.generateMethodBody()
+      }
+    }
   }
 
-  private fun generateMethodBody(
-    fn: IrSimpleFunction,
-    annotation: AnnotationConfig
-  ): IrBlockBody {
-    val parentClass = fn.parentAsClass
-    return DeclarationIrBuilder(pluginContext, fn.symbol).irBlockBody(fn) {
-      val thisRef = irGet(fn.dispatchReceiverParameter!!)
+  private inner class ToStringFunctionBodyBuilder(
+    private val irFunction: IrSimpleFunction,
+    private val annotation: AnnotationConfig,
+  ) : AbstractClassFunctionBlockBodyBuilder (
+    irFunction,
+    pluginContext,
+    Scope(irFunction.symbol),
+    SYNTHETIC_OFFSET,
+    SYNTHETIC_OFFSET
+  ) {
+
+    private val parentClass = irFunction.parentAsClass
+
+    fun generateMethodBody() {
       val result = irConcat()
       result.arguments.add(irString(parentClass.name.asString() + "("))
 
+      var isFirstArgument = true
       if (annotation.callSuper) {
-        val superFn = resolveSuperFunction(fn)
+        val superFn = resolveSuperFunction(irFunction)
         result.arguments.add(irString("super="))
         result.arguments.add(
           irCall(superFn.symbol).apply {
-            dispatchReceiver = thisRef
+            dispatchReceiver = irThis()
             superQualifierSymbol = superFn.parentAsClass.symbol
           })
 
-        result.arguments.add(irString(", "))
+        isFirstArgument = false
       }
 
-      var hasIncludedField = false
       parentClass.acceptChildrenVoid(object : IrVisitorVoid() {
-
         override fun visitProperty(declaration: IrProperty) {
           if (declaration.origin != IrDeclarationOrigin.Companion.DEFINED) return
-          val getter = declaration.getter ?: return
+          if (declaration.getter == null) return
           val hasBackingField = declaration.backingField != null
 
           val config = getPropertyConfig(declaration)
           if (!config.isIncluded(annotation, !hasBackingField)) return
 
-          if (annotation.doNotUseGetters && hasBackingField) {
-            handleField(declaration.backingField!!, config)
-            return
-          }
+          if (!isFirstArgument) result.arguments.add(irString(", "))
+          isFirstArgument = false
 
-          hasIncludedField = true
           val outputName = config?.customName ?: declaration.name.asString()
           result.arguments.add(irString("$outputName="))
-          result.arguments.add(irCall(getter.symbol).apply {
-            dispatchReceiver = thisRef
-          })
-
-          result.arguments.add(irString(", "))
-        }
-
-        override fun visitField(declaration: IrField) {
-          // Property fields are handled by visitProperty
-          if (declaration.isPropertyField) return
-          val config = getElementConfig(declaration.annotations)
-          if (!config.isIncluded(annotation)) return
-          handleField(declaration, config)
-        }
-
-        private fun handleField(declaration: IrField, config: ElementConfig?) {
-          hasIncludedField = true
-          val outputName = config?.customName ?: declaration.name.asString()
-          result.arguments.add(irString("$outputName="))
-          result.arguments.add(irGetField(thisRef, declaration))
-          result.arguments.add(irString(", "))
+          result.arguments.add(irGetProperty(declaration, annotation.doNotUseGetters))
         }
       })
 
-      if (hasIncludedField) {
-        result.arguments.removeAt(result.arguments.size - 1)
-      }
-
       result.arguments.add(irString(")"))
+
       +irReturn(result)
     }
-  }
 
-  @OptIn(UnsafeDuringIrConstructionAPI::class)
-  private fun resolveSuperFunction(fn: IrSimpleFunction): IrSimpleFunction {
-    val parentClass = fn.parentAsClass
-    if (parentClass.superClass == null)
-      messageCollector.report(
-        CompilerMessageSeverity.WARNING,
-        "ToString on ${parentClass.kotlinFqName} requires super call but the class has no super class"
-      )
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    private fun irGetProperty(property: IrProperty, doNotUseGetter: Boolean): IrExpression {
+      with(property) {
+        if (doNotUseGetter && backingField != null)
+          return irGetThisField(backingField!!)
 
-    return (parentClass.superClass ?: pluginContext.irBuiltIns.anyClass.owner)
-      .functions
-      .singleOrNull {
-        it.name == LomboktNames.TO_STRING_METHOD_NAME && it.valueParameters.isEmpty()
-      }!!
+        if (!isLateinit) return irGetThisProperty(property)
+        return irGetThisLateInitProperty(property, irString(UNINITIALIZED))
+      }
+    }
+
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    private fun resolveSuperFunction(fn: IrSimpleFunction): IrSimpleFunction {
+      val parentClass = fn.parentAsClass
+      if (parentClass.superClass == null)
+        messageCollector.report(
+          CompilerMessageSeverity.WARNING,
+          "ToString on ${parentClass.kotlinFqName} requires super call but the class has no super class"
+        )
+
+      return (parentClass.superClass ?: pluginContext.irBuiltIns.anyClass.owner)
+        .functions
+        .singleOrNull {
+          it.name == LomboktNames.TO_STRING_METHOD_NAME && it.valueParameters.isEmpty()
+        }!!
+    }
   }
 
   private fun getAnnotationAttributes(klass: IrClass): AnnotationConfig {

--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
@@ -89,8 +89,10 @@ class ToStringIrBodyGenerator(
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     private fun irGetProperty(property: IrProperty, doNotUseGetter: Boolean): IrExpression {
       with(property) {
-        if (isLateinit || (doNotUseGetter && backingField != null))
+        if (doNotUseGetter && backingField != null)
           return irGetThisField(backingField!!)
+
+        if (isLateinit) return irGetThisLateInitProperty(property, irNull())
 
         return irGetThisProperty(this)
       }

--- a/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
+++ b/lombokt-plugin/backend/src/main/kotlin/com/bivektor/lombokt/ir/ToStringIrBodyGenerator.kt
@@ -17,8 +17,6 @@ import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.name.Name
 
-private const val UNINITIALIZED = "<uninitialized>"
-
 class ToStringIrBodyGenerator(
   private val pluginContext: IrPluginContext,
   private val messageCollector: MessageCollector
@@ -91,11 +89,10 @@ class ToStringIrBodyGenerator(
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     private fun irGetProperty(property: IrProperty, doNotUseGetter: Boolean): IrExpression {
       with(property) {
-        if (doNotUseGetter && backingField != null)
+        if (isLateinit || (doNotUseGetter && backingField != null))
           return irGetThisField(backingField!!)
 
-        if (!isLateinit) return irGetThisProperty(property)
-        return irGetThisLateInitProperty(property, irString(UNINITIALIZED))
+        return irGetThisProperty(this)
       }
     }
 

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
@@ -200,4 +200,17 @@ class ToStringTest {
   fun shouldSkipWhenSuperMethodFinal() {
     assertEquals("fromSuper", SuperMethodFinal().toString())
   }
+
+  @ToString
+  private class LateInitProperty {
+    lateinit var name: String
+  }
+
+  @Test
+  fun testLateInitProperty() {
+    val v = LateInitProperty()
+    assertEquals("LateInitProperty(name=<uninitialized>)", v.toString())
+    v.name = "John"
+    assertEquals("LateInitProperty(name=John)", v.toString())
+  }
 }

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/ToStringTest.kt
@@ -209,7 +209,7 @@ class ToStringTest {
   @Test
   fun testLateInitProperty() {
     val v = LateInitProperty()
-    assertEquals("LateInitProperty(name=<uninitialized>)", v.toString())
+    assertEquals("LateInitProperty(name=null)", v.toString())
     v.name = "John"
     assertEquals("LateInitProperty(name=John)", v.toString())
   }


### PR DESCRIPTION
This PR mimics how `::isInitialized` creates bytecode which is actually a null check on the field and if not null, calling the getter.

I verified this by first calling `KProperty.isInitialized` extension function through a reference function and property reference and the decompiled code was just something like `this.prop == null ? null : this.getProp()`