### PR TITLE
LOMBOKT-48: API docs for annotations

### DIFF
--- a/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts
@@ -1,0 +1,31 @@
+import gradle.kotlin.dsl.accessors._cb6cb9110f5ef9edc63ba98f09b0c2ae.dokkaJavadoc
+import org.jetbrains.dokka.gradle.DokkaTask
+import java.net.URL
+
+plugins {
+  id("org.jetbrains.dokka")
+}
+
+val kotlinToolChainVersion: String by project
+val githubRepo: String by project
+
+tasks.withType<DokkaTask>().configureEach {
+  dokkaSourceSets.configureEach {
+    languageVersion.set(kotlinToolChainVersion)
+    apiVersion.set(kotlinToolChainVersion)
+
+    sourceLink {
+      remoteUrl.set(URL("https://github.com/$githubRepo/tree/main/$project.name/src/main/kotlin"))
+      localDirectory.set(file("src/main/kotlin"))
+      remoteLineSuffix.set("#L")
+    }
+  }
+}
+
+the<JavaPluginExtension>().withJavadocJar()
+
+tasks.named<Jar>("javadocJar") {
+  dependsOn(tasks.dokkaJavadoc)
+  from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+  archiveClassifier.set("javadoc")
+}

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -4,15 +4,21 @@ plugins {
   id("io.deepmedia.tools.deployer")
 }
 
+the<JavaPluginExtension>().apply {
+  if (hasJavaDocs)
+    withJavadocJar()
+}
+
 the<DeployerExtension>().apply {
   projectInfo {
-    val scmUrl = "https://github.com/bivektor/lombokt"
+    val githubRepo: String by project
+    val githubUrl = "https://github.com/$githubRepo"
 
-    url = scmUrl
+    url = githubUrl
     scm {
-      connection = "scm:git:git://github.com/bivektor/${scmUrl}.git"
+      connection = "scm:git:git://github.com/${githubRepo}.git"
       developerConnection = connection
-      url = scmUrl
+      url = githubUrl
     }
 
     license(apache2)
@@ -27,7 +33,8 @@ the<DeployerExtension>().apply {
   content {
     component {
       fromJava()
-      emptyDocs()
+      if (!hasJavaDocs)
+        emptyDocs()
     }
   }
 
@@ -49,3 +56,5 @@ the<DeployerExtension>().apply {
     }
   }
 }
+
+private val Project.hasJavaDocs get() = pluginManager.hasPlugin("org.jetbrains.dokka")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ group=com.bivektor.lombokt
 version=3.0.0-beta.4
 mavenVersion=4.0.0
 kotlinToolChainVersion=17
+githubRepo=bivektor/lombokt
+org.gradle.configuration.cache=true

--- a/lombokt-api/build.gradle.kts
+++ b/lombokt-api/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("dokka-conventions")
   id("publishing-conventions")
 }
 

--- a/lombokt-api/gradle.properties
+++ b/lombokt-api/gradle.properties
@@ -1,2 +1,3 @@
 kotlin.stdlib.default.dependency=false
 description=Lombokt annotations for Kotlin
+withJavaDocs=true

--- a/lombokt-api/src/main/kotlin/lombokt/Buildable.kt
+++ b/lombokt-api/src/main/kotlin/lombokt/Buildable.kt
@@ -1,9 +1,65 @@
 package lombokt
 
+/**
+ * Marks a class as **Buildable**, indicating that a nested **Builder** class exists to construct instances of it.
+ *
+ * A **Buildable** class must:
+ * - Have a **primary constructor**.
+ * - Contain a **nested class** annotated with [Builder].
+ *
+ * This annotation supports **regular classes** and **data classes**.
+ * It does **not** support **inner classes, objects, interfaces, enums, inline, or local classes**.
+ *
+ * See [Builder] for details on implementing a builder.
+ */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 annotation class Buildable {
 
+  /**
+   * Marks a **nested class** as the **Builder** for its enclosing **Buildable** class.
+   *
+   * The **Builder** class must:
+   * - Be a **nested class** inside a class annotated with [Buildable].
+   * - Declare a **setter method** for each **constructor parameter** in the enclosing class.
+   * - Provide a **`build()` method** that returns an instance of the enclosing class.
+   *
+   * #### **Method Requirements**
+   * - Each setter method must have the **same name** as the corresponding constructor parameter.
+   * - Each setter method must have a single parameter of the same type as the corresponding constructor parameter.
+   * - Each setter method must return the **Builder instance** to allow method chaining.
+   * - The `build()` method must return an instance of the enclosing class.
+   *
+   * **Lombokt automatically overrides all method bodies that match these criteria.**
+   * For this reason, the simplest way to define a Builder class is:
+   * - Return `this` in setter methods.
+   * - Throw an error in the `build()` method.
+   *
+   * #### **Example**
+   * ```kotlin
+   * @Buildable
+   * class Person(val name: String) {
+   *
+   *     @Buildable.Builder
+   *     class Builder {
+   *         fun name(name: String) = this
+   *         fun build(): Person = error("not implemented")
+   *     }
+   * }
+   * ```
+   *
+   * **How Lombokt Generates the Builder Implementation:**
+   * - It creates **private nullable properties** in the Builder class, corresponding to the constructor parameters.
+   * - Each setter method updates the corresponding private property.
+   * - The `build()` method calls the **constructor** of the Buildable class, passing the values from the Builder properties.
+   *
+   * #### **Handling Default Values**
+   * If a **constructor parameter has a default value**, Lombokt ensures:
+   * - If the property is **unset**, the default value is used when calling the constructor.
+   * - If the property is **nullable but has a non-null default value**, Lombokt cannot distinguish between an **unset property**
+   *   and one explicitly set to `null`.
+   *   In this case, Lombokt generates an **additional private Boolean flag** to track whether the property was explicitly set.
+   */
   @Target(AnnotationTarget.CLASS)
   @Retention(AnnotationRetention.SOURCE)
   annotation class Builder

--- a/lombokt-api/src/main/kotlin/lombokt/EqualsAndHashCode.kt
+++ b/lombokt-api/src/main/kotlin/lombokt/EqualsAndHashCode.kt
@@ -1,20 +1,66 @@
 package lombokt
 
+/**
+ * Generates `equals` and `hashCode` methods for the annotated class based on its properties.
+ *
+ * If either of these methods is declared by the annotated class or one of its super classes as `final` (preventing overrides),
+ * code generation is skipped.
+ *
+ * This annotation supports only regular classes and data classes. It does not work with objects, interfaces, inner,
+ * local, inline, or enum classes.
+ *
+ * By default, it includes all properties with a backing field. For **regular classes**, this means all properties
+ * from the primary constructor (if present) and properties declared in the class body. For **data classes**, only
+ * primary constructor properties are included.
+ *
+ * Setting [onlyExplicitlyIncluded] to `true` disables the default convention, requiring properties to be explicitly
+ * marked with [Include]. However, in **data classes**, [Include] cannot override the default behavior,
+ * meaning properties declared in the class body are always excluded. Since data classes already generate `equals`
+ * and `hashCode`, this annotation is only useful for excluding specific properties from their equality logic.
+ *
+ * By default, property getters are used when generating methods. To use backing fields instead, set [doNotUseGetters]
+ * to `true`.
+ *
+ * The generated equality and hash code logic closely follows Kotlin's data class behavior. This ensures consistency,
+ * but note that **arrays do not compare their elements** in `equals` and `hashCode` methods. As a result, array
+ * comparisons may not work as expected.
+ */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 annotation class EqualsAndHashCode(
   /**
-   * When set to `true` only properties explicitly included via [Include] annotation are used.Defaults to `false`
+   * When `true`, only properties explicitly marked with [Include] are considered. Defaults to `false`.
    */
   val onlyExplicitlyIncluded: Boolean = false,
+
+  /**
+   * When `true`, includes superclass implementations of `equals` and `hashCode`. Defaults to `false`.
+   *
+   * For `equals`, if `super.equals` returns `false`, the generated method also returns `false`. This means classes
+   * without a superclass (implicitly inheriting from `Any`) should not call `super.equals`, since `Any` implements
+   * equality using **object identity**, which only considers two references equal if they point to the same instance.
+   *
+   * In general, overriding equality methods in subclasses is discouraged unless you fully control or understand
+   * how the superclass implements them.
+   */
   val callSuper: Boolean = false,
+
+  /**
+   * When `true`, uses backing fields instead of property getters. Defaults to `false`.
+   */
   val doNotUseGetters: Boolean = false,
 ) {
 
+  /**
+   * Marks a property for inclusion in the equality logic when [onlyExplicitlyIncluded] is `true`.
+   */
   @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
   @Retention(AnnotationRetention.SOURCE)
   annotation class Include()
 
+  /**
+   * Excludes a property from the equality logic.
+   */
   @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
   @Retention(AnnotationRetention.SOURCE)
   annotation class Exclude()

--- a/lombokt-api/src/main/kotlin/lombokt/ToString.kt
+++ b/lombokt-api/src/main/kotlin/lombokt/ToString.kt
@@ -1,17 +1,63 @@
 package lombokt
 
+/**
+ * Generates a `toString` method for the annotated class based on its properties.
+ *
+ * The method is only generated if the class does not already declare `toString` and if no superclass
+ * declares it as `final` which prevents us from overriding it.
+ *
+ * This annotation supports **regular classes**, **objects**, **nested**, and **inner classes**, as well as **data classes**.
+ * It does **not** support interfaces, local, inline, or enum classes.
+ *
+ * By default, it includes all properties with a backing field. Properties from both the **primary constructor** (if present)
+ * and the **class body** including `lateinit` properties are included. **Getter-only properties** (without a backing field)
+ * are **not included by default** but can be explicitly included via [Include].
+ *
+ * To override this default inclusion:
+ * - Use [Exclude] annotation to exclude specific properties
+ * - Set [onlyExplicitlyIncluded] to `true` and use [Include] to explicitly mark properties for inclusion.
+ *
+ * By default, `toString` calls **property getters** to obtain values. To use backing fields instead, set [doNotUseGetters] to `true`.
+ *
+ * #### **Generated Output Format**
+ * The generated `toString` method follows this format:
+ * ```
+ * <ShortClassName>(property1=value1, property2=value2, ...)
+ * ```
+ */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 annotation class ToString(
+  /**
+   * When `true`, only properties explicitly marked with [Include] are included in `toString()`. Defaults to `false`.
+   */
   val onlyExplicitlyIncluded: Boolean = false,
+
+  /**
+   * When `true`, includes the super class's `toString()` output as the first item in the generated method.
+   * The output will be formatted as `super=<super.toString()>`. Defaults to `false`.
+   */
   val callSuper: Boolean = false,
+
+  /**
+   * When `true`, uses backing fields instead of calling property getters.
+   * **Getter-only properties (without backing fields) are not affected**. Defaults to `false`.
+   */
   val doNotUseGetters: Boolean = false
 ) {
 
+  /**
+   * Marks a property to be explicitly included in the `toString()` output.
+   *
+   * @param name Overrides the property name in the generated output.
+   */
   @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
   @Retention(AnnotationRetention.SOURCE)
   annotation class Include(val name: String = "")
 
+  /**
+   * Marks a property to be excluded from the `toString()` output.
+   */
   @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
   @Retention(AnnotationRetention.SOURCE)
   annotation class Exclude()


### PR DESCRIPTION
Closes #48 

Added KDoc comments to Lombokt annotations, configured Dokka to build javadoc jar for the lombokt-api project and tested IDE support with the maven example project. The problem is, Dokka javadoc generator is in alpha and it just ignored annotation parameter doc comments.  