### PR TITLE
LOMBOKT-50: Fix FIR annotation lookup logic

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 dependencies {
   val kotlinVersion: String by project
   implementation(kotlin("gradle-plugin", version = kotlinVersion))
+  implementation("org.jetbrains.kotlin.plugin.allopen:org.jetbrains.kotlin.plugin.allopen.gradle.plugin:$kotlinVersion")
+  implementation("org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin:$kotlinVersion")
 
   val deployerPluginVersion: String by project
   implementation("io.deepmedia.tools.deployer:io.deepmedia.tools.deployer.gradle.plugin:$deployerPluginVersion")

--- a/lombokt-plugin/api/lombokt-plugin.api
+++ b/lombokt-plugin/api/lombokt-plugin.api
@@ -116,16 +116,16 @@ public class com/bivektor/lombokt/fir/generators/ToStringGenerator : org/jetbrai
 
 public abstract class com/bivektor/lombokt/fir/services/AnnotatedClassMatchingService : org/jetbrains/kotlin/fir/extensions/FirExtensionSessionComponent {
 	public fun <init> (Lorg/jetbrains/kotlin/fir/FirSession;Lorg/jetbrains/kotlin/name/FqName;)V
-	public final fun getAnnotationName ()Lorg/jetbrains/kotlin/name/FqName;
-	public final fun isAnnotated (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassLikeSymbol;)Z
+	public final fun isAnnotated (Lorg/jetbrains/kotlin/fir/symbols/impl/FirRegularClassSymbol;)Z
+	public fun registerPredicates (Lorg/jetbrains/kotlin/fir/extensions/FirDeclarationPredicateRegistrar;)V
 }
 
 public final class com/bivektor/lombokt/fir/services/BuildableService : org/jetbrains/kotlin/fir/extensions/FirExtensionSessionComponent {
 	public fun <init> (Lorg/jetbrains/kotlin/fir/FirSession;)V
-	public final fun isBuildableClass (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassSymbol;)Z
 	public final fun isBuilderClass (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassSymbol;)Z
 	public final fun isSuitableBuildableClassType (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassSymbol;)Z
 	public final fun isSuitableBuilderClassType (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassSymbol;)Z
+	public fun registerPredicates (Lorg/jetbrains/kotlin/fir/extensions/FirDeclarationPredicateRegistrar;)V
 }
 
 public final class com/bivektor/lombokt/fir/services/BuildableServiceKt {

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktCheckersComponent.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/checkers/LomboktCheckersComponent.kt
@@ -9,6 +9,10 @@ class LomboktCheckersComponent(session: FirSession) : FirAdditionalCheckersExten
   override val declarationCheckers: DeclarationCheckers
     get() = object: DeclarationCheckers() {
       override val classCheckers: Set<FirClassChecker>
-        get() = setOf(ToStringClassChecker, EqualsAndHashCodeClassChecker, BuildableClassChecker)
+        get() = setOf(
+          ToStringClassChecker,
+          EqualsAndHashCodeClassChecker,
+          BuildableClassChecker
+        )
     }
 }

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/BuildableGenerator.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/BuildableGenerator.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
-
 private val builderPropertiesCallableName = Name.identifier("Lombokt.builderClassProperties")
 
 class BuildableGenerator(session: FirSession) : FirDeclarationGenerationExtension(session) {
@@ -29,10 +28,8 @@ class BuildableGenerator(session: FirSession) : FirDeclarationGenerationExtensio
   private val buildableService: BuildableService by lazy { session.buildableService }
 
   override fun getCallableNamesForClass(classSymbol: FirClassSymbol<*>, context: MemberGenerationContext): Set<Name> {
-    // All these checks are necessary because even FIR declaration checker fails, our generator methods below may still run causing unexpected errors
-    if (!buildableService.isSuitableBuilderClassType(classSymbol)) return emptySet()
     if (!buildableService.isBuilderClass(classSymbol)) return emptySet()
-    if (!buildableService.isSuitableBuildableClassType(classSymbol.getContainingClassSymbol() as FirClassSymbol<*>)) return emptySet()
+    if (!buildableService.isSuitableBuilderClassType(classSymbol)) return emptySet()
     return setOf(builderPropertiesCallableName)
   }
 

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/ToStringGenerator.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/generators/ToStringGenerator.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.plugin.createMemberFunction
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.Name
 
@@ -31,6 +32,7 @@ open class ToStringGenerator(
   }
 
   private fun isSuitableClass(classSymbol: FirClassSymbol<*>): Boolean {
+    if (classSymbol !is FirRegularClassSymbol) return false
     return toStringService.isSuitableClassType(classSymbol) && toStringService.isAnnotated(classSymbol)
   }
 

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/AnnotatedClassMatchingService.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/AnnotatedClassMatchingService.kt
@@ -4,25 +4,32 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.caches.getValue
-import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
-import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.fir.extensions.predicate.DeclarationPredicate.BuilderContext.annotated
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.name.FqName
 
 abstract class AnnotatedClassMatchingService(
-  session: FirSession, val annotationName: FqName
+  session: FirSession, annotationName: FqName
 ) : FirExtensionSessionComponent(session) {
 
+  private val predicate = annotated(annotationName)
+
+  override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+    register(predicate)
+  }
+
   @Suppress("UNUSED_ANONYMOUS_PARAMETER")
-  private val cache: FirCache<FirClassLikeSymbol<*>, Boolean, Nothing?> =
+  private val cache: FirCache<FirRegularClassSymbol, Boolean, Nothing?> =
     session.firCachesFactory.createCache { symbol, _ -> symbol.matches() }
 
-  fun isAnnotated(symbol: FirClassLikeSymbol<*>): Boolean {
+  fun isAnnotated(symbol: FirRegularClassSymbol): Boolean {
     return cache.getValue(symbol)
   }
 
-  private fun FirClassLikeSymbol<*>.matches(): Boolean {
-    return hasAnnotation(ClassId.topLevel(annotationName), session)
+  private fun FirRegularClassSymbol.matches(): Boolean {
+    return session.predicateBasedProvider.matches(predicate, this)
   }
 }

--- a/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/EqualsAndHashCodeService.kt
+++ b/lombokt-plugin/k2/src/main/kotlin/com/bivektor/lombokt/fir/services/EqualsAndHashCodeService.kt
@@ -20,10 +20,10 @@ import org.jetbrains.kotlin.fir.declarations.utils.isData
 import org.jetbrains.kotlin.fir.declarations.utils.isInline
 import org.jetbrains.kotlin.fir.declarations.utils.isInner
 import org.jetbrains.kotlin.fir.declarations.utils.isLocal
-import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 import com.bivektor.lombokt.LomboktNames.EQUALS_HASHCODE_ANNOTATION_NAME as ANNOTATION_NAME
@@ -85,12 +85,11 @@ class EqualsAndHashCodeService(session: FirSession) : AnnotatedClassMatchingServ
   }
 
   fun isSuitableClassType(symbol: FirClassSymbol<*>): Boolean {
+    if (symbol !is FirRegularClassSymbol) return false
+
     return when {
       // Allow only regular classes not objects, enum classes & entries, interfaces, annotation classes
       symbol.classKind != ClassKind.CLASS -> false
-
-      // Disallow anonymous objects
-      symbol is FirAnonymousObjectSymbol -> false
 
       // Disallow special types
       symbol.isInline || symbol.isValueClass || symbol.isLocal || symbol.isInner -> false

--- a/plugin-test/build.gradle.kts
+++ b/plugin-test/build.gradle.kts
@@ -1,4 +1,14 @@
+plugins {
+  kotlin("plugin.allopen")
+  kotlin("plugin.serialization")
+}
+
 dependencies {
   kotlinCompilerPluginClasspath(project(":lombokt-plugin"))
   testCompileOnly(project(":lombokt-api"))
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.8.1")
+}
+
+allOpen {
+  annotation("lombokt.Buildable")
 }

--- a/plugin-test/src/test/kotlin/com/bivektor/lombokt/CombinedAnnotationTest.kt
+++ b/plugin-test/src/test/kotlin/com/bivektor/lombokt/CombinedAnnotationTest.kt
@@ -1,5 +1,7 @@
 package com.bivektor.lombokt
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import lombokt.Buildable
 import lombokt.EqualsAndHashCode
 import lombokt.ToString
@@ -13,7 +15,10 @@ class CombinedAnnotationTest {
   @Buildable
   @ToString
   @EqualsAndHashCode
+  @Serializable
   class Person(val name: String = "x", var surname: String = "y") {
+
+    fun some() = 10
 
     @Buildable.Builder
     class Builder {
@@ -31,5 +36,25 @@ class CombinedAnnotationTest {
     assertEquals(p1.hashCode(), p2.hashCode())
     assertEquals("Person(name=x, surname=y)", p1.toString())
     assertNotEquals(p1, Person.Builder().name("a").build())
+  }
+
+  @Test
+  fun testSerializationNotBroken() {
+    val p = Person.Builder().name("John").surname("Doe").build()
+    assertEquals("John", p.name)
+    assertEquals("Doe", p.surname)
+    val serialized = Json.encodeToString(Person.serializer(), p)
+    val deserialized = Json.decodeFromString(Person.serializer(), serialized)
+    assertEquals(p, deserialized)
+  }
+
+  @Test
+  fun allOpenNotBroken() {
+    class PersonDerived : Person() {
+      override fun some(): Int = 11
+    }
+
+    val p = PersonDerived()
+    assertEquals(11, p.some())
   }
 }


### PR DESCRIPTION
Closes #50 

* Use `session.predicateBasedProvider` for checking if a class is annotated with a specific annotation
* Simplify Builder class search by combined annotation predicate based on the class and its parent
* Move existing `equals` and `hashcode` method search from `getCallableNamesForClass` method because it was throwing similar exception
* Update API spec
* Add tests for combined behavior using our annotations and `all-open` and `serializable` annotations